### PR TITLE
Persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ error_logs.log
 info_logs.log
 __pycache__
 .vscode
+persistent_bot_state.pkl

--- a/telegram_interaction.py
+++ b/telegram_interaction.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import telegram
-from telegram.ext import Updater, CommandHandler
+from telegram.ext import Updater, CommandHandler, PicklePersistence
 from telegram.error import Unauthorized
 import logging
 
@@ -573,7 +573,8 @@ def handle_error(update, context):
 
 if __name__ == "__main__":
     # Set up the bot
-    updater = Updater(token=TOKEN)
+    persistence = PicklePersistence(filename='persistent_bot_state.pkl')
+    updater = Updater(token=TOKEN, persistence=persistence)
     dispatcher = updater.dispatcher
 
     # Static command handlers


### PR DESCRIPTION
This change implements persistence of the bot state. This allows us to to restart the bot
without losing the game state (which is saved in context.bot_state

The following states are persistent:
store_user_data
store_chat_data
store_bot_data

The state is saved in a python pickle file

Fixes issue https://github.com/jaapert/Monopoly-Telegram-Bot/issues/16