### PR TITLE
fix bankrupt

### DIFF
--- a/monopoly.py
+++ b/monopoly.py
@@ -1433,7 +1433,7 @@ class Game:
         self.turn = self.ids[self.turn % len(self.players.keys())]
 
         self.pending_trade = None
-        self.pending_payments = None
+        self.pending_payments.clear()
         self.has_doubles = False
         self.last_roll = [-1]
 


### PR DESCRIPTION
Pending is a list, need to empty it, not set it to None

Fixes:

```
error_logger - WARNING - Telegram Error!   File "dispatcher.py", line 555, in process_update
    handler.handle_update(update, self, check, context)
  File "/handler.py", line 198, in handle_update
    return self.callback(update, context)
  File "/telegram_interaction.py", line 357, in end_turn_handler
    game.end_turn(user_id)
  File "/monopoly.py", line 489, in end_turn
    if len(self.pending_payments) > 0:
 with context error object of type 'NoneType' has no len() caused by this update:
```