### PR TITLE
output assets as table

### DIFF
--- a/monopoly.py
+++ b/monopoly.py
@@ -3,11 +3,11 @@
 from __future__ import unicode_literals
 
 from typing import Dict, List, Optional
+import random
 
 from PIL import Image, ImageDraw
 from colorhash import ColorHash
-
-import random
+import prettytable
 
 class Dice:
     def __init__(self, dice_count, sides):
@@ -90,21 +90,32 @@ class Player:
                 return p
 
     def get_properties_str(self):
-        text = self.name + " properties:\n\n"
-        count = 0
-        for p in self.properties:
+        table = prettytable.PrettyTable()
+        table.field_names = ["id", "name", "color", "price", "mort", "#", "rent"]
+        for (id, p) in enumerate(self.properties):
+            is_mort = "Y" if p.get_mortgaged() else "N"
+
             if type(p) == Property:
-                text += "(" + str(count) + ") " + p.get_name() + " : " + p.get_color() + \
-                        " (" + str(p.get_houses()) + " houses " + "($" + str(p.get_house_cost()) + "), " + \
-                        str(p.get_hotels()) + " hotels " + "($" + str(p.get_hotel_cost()) + "))" + \
-                        " [Mortgage Value: " + str(p.get_mortgage_value()) + "] " + \
-                        ("[[Mortgaged]]\n" if p.get_mortgaged() else "\n")
+                table.add_row([
+                    id,
+                    p.get_name(),
+                    p.get_color(),
+                    p.cost,
+                    f"{is_mort} ({p.get_mortgage_value()})",
+                    "H" if p.get_hotels() > 0 else str(p.get_houses()),
+                    p.get_rent(),
+                ])
             elif type(p) == OtherProperty:
-                text += "(" + str(count) + ") " + p.get_name() + " : " + p.get_type() + \
-                        " [Mortgage Value: " + str(p.get_mortgage_value()) + "] " + \
-                        ("[[Mortgaged]]\n" if p.get_mortgaged() else "\n")
-            count += 1
-        return text
+                table.add_row([
+                    id,
+                    p.get_name(),
+                    p.get_type(),
+                    p.cost,
+                    f"{is_mort} ({p.get_mortgage_value()})",
+                    '',
+                    p.get_rent(),
+                ])
+        return self.name + " properties:\n\n" + table.get_string()
 
     def get_position(self):
         return self.position
@@ -180,6 +191,7 @@ class Property:
         self.cost = cost
         self.mortgaged = False
         self.owner = None
+
 
     def add_house(self):
         if self.houses < 4 and self.hotels == 0:

--- a/poetry.lock
+++ b/poetry.lock
@@ -336,6 +336,23 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "prettytable"
+version = "3.8.0"
+description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "prettytable-3.8.0-py3-none-any.whl", hash = "sha256:03481bca25ae0c28958c8cd6ac5165c159ce89f7ccde04d5c899b24b68bb13b7"},
+    {file = "prettytable-3.8.0.tar.gz", hash = "sha256:031eae6a9102017e8c7c7906460d150b7ed78b20fd1d8c8be4edaf88556c07ce"},
+]
+
+[package.dependencies]
+wcwidth = "*"
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "pytest-lazy-fixture"]
+
+[[package]]
 name = "pytest"
 version = "7.4.0"
 description = "pytest: simple powerful testing with Python"
@@ -515,7 +532,18 @@ tzdata = {version = "*", markers = "platform_system == \"Windows\""}
 [package.extras]
 devenv = ["black", "check-manifest", "flake8", "pyroma", "pytest (>=4.3)", "pytest-cov", "pytest-mock (>=3.3)", "zest.releaser"]
 
+[[package]]
+name = "wcwidth"
+version = "0.2.6"
+description = "Measures the displayed width of unicode strings in a terminal"
+optional = false
+python-versions = "*"
+files = [
+    {file = "wcwidth-0.2.6-py2.py3-none-any.whl", hash = "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e"},
+    {file = "wcwidth-0.2.6.tar.gz", hash = "sha256:a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0"},
+]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8 <4.0"
-content-hash = "6aa307526b40b95f8a283abc18670408277f02ae33211647e4d451a3c0624255"
+content-hash = "0a2de2ea9b35916a2c903454973c1eca01d37997adea8fe87528103a2493e2ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ pillow = "^10.0.0"
 colorhash = "^1.2.1"
 python-telegram-bot = "<=13.10"
 mock = "^5.1.0"
+prettytable = "^3.8.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/telegram_interaction.py
+++ b/telegram_interaction.py
@@ -64,7 +64,8 @@ def check_game_existence(chat_id, game):
 
 def send_info(bot, chat_id, game, user_id, send_id):
     player = game.players.get(user_id)
-    props = player.get_properties_str()
+    props = f"```\n{player.get_properties_str()}\n```"
+    props = props + "Note: Table doesn't account for Monop, railroad & utility scaling\n"
     money = player.get_money()
     cards = player.get_get_out_free_cards()
     total_assets = player.get_total_assets()

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 #
-poetry run python -m pytest
+poetry run python -m pytest -vv

--- a/tests/test_monop.py
+++ b/tests/test_monop.py
@@ -144,3 +144,21 @@ def test_bankrupt_bankr(game):
     assert properties[1].owner == None
 
 
+def test_asset_printer(game, capsys):
+    p0 = game.get_players()[0]
+
+    prop_pos = [1,3,5,6,8,9, 15]
+    for pos in prop_pos:
+        p0.set_position(pos)
+        game.purchase_property(p0.id)
+    game.clear_messages()
+    assert len(p0.get_properties()) == len(prop_pos)
+    p0.get_properties()[2].hotels = 1
+    p0.get_properties()[3].houses = 4
+    p0.get_properties()[4].houses = 4
+
+    ps = p0.get_properties_str()
+    with capsys.disabled():
+        print(ps)
+
+


### PR DESCRIPTION
This turns the output into a table:

```
+----+-----------------------+---------------+-------+---------+---+------+
| id |          name         |     color     | price |   mort  | # | rent |
+----+-----------------------+---------------+-------+---------+---+------+
| 0  |  Mediterranean Avenue |    Brown 🟫   |   60  |  N (30) | 0 |  2   |
| 1  |     Baltic Avenue     |    Brown 🟫   |   60  |  N (30) | 0 |  4   |
| 2  |    Oriental Avenue    | Light Blue ⬜️ |  100  |  N (50) | H | 550  |
| 3  |     Vermont Avenue    | Light Blue ⬜️ |  100  |  N (50) | 4 | 400  |
| 4  |   Connecticut Avenue  | Light Blue ⬜️ |  120  |  N (60) | 4 | 450  |
| 5  |    Reading Railroad   |    Railroad   |  200  | N (100) |   |  25  |
| 6  | Pennsylvania Railroad |    Railroad   |  200  | N (100) |   |  25  |
+----+-----------------------+---------------+-------+---------+---+------+
```

Makes it clear what the holdings are and a good indication of rent. The rent is not completely accurate as its calculated per property. Streets and RR/Utility need special handling, still better than nothing tho

On mobile this doesn't render great, should add the ability to have an alternative format